### PR TITLE
Implemented interface module with tests

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -1,8 +1,31 @@
+# coding=utf-8
+# War -> Interface
+
+# XXX Deprecated
 def display_hand(hum, cpu):
     print("Your card is {}! Computer's card is {}!".format(hum, cpu))
 
-def output(string="", wait=False, prompt=">>"):
-    print(string, end="")
-    if wait:
-        input(prompt)
-    
+
+# Tested
+def output(string="", outFn=print):
+    """Print a message to the user. The print function can be overridden
+    for testing, logging, or alternative interfaces."""
+
+    outFn(string, end="")
+
+
+# Tested
+def wait_for_input(disabled=False, prompt=">>> "):
+    """Return nothing only after user input.
+    Function can be disabled by argument for testing purposes."""
+
+    if not disabled: input(prompt)
+
+
+# On hold until we can come to a consensus on how to represent suits
+def unicode_repr(card):
+    """Return the unicode character for a given card.
+    If only a suit is given, return the suit's symbol.
+    """
+
+    return None

--- a/test_interface.py
+++ b/test_interface.py
@@ -1,0 +1,17 @@
+# coding=utf-8
+# War -> Tests -> Interface
+
+import interface
+
+def test_output():
+    console = []
+    interface.output("Butts", outFn=lambda s, end: console.append(s+end))
+    assert "Butts" in console
+
+def test_unicode_repr(): 
+    assert "Not implemented yet"
+
+
+def test_wait_disabling():
+    interface.wait_for_input(disabled=True)
+    assert "If we reach this point it works!"


### PR DESCRIPTION
I've added a new function <code>wait_for_input()</code>, which can be disabled at will by passing an argument <code>disabled=True</code>. This will make test runs easier to deal with. I modified <code>output()</code> to remove the wait function, as it is now redundant, and to add an option to select a different printing function for testing or special uses like logging. 

<code>display_hand()</code> will be removed after I can take out any calls to it from <code>main.py</code>.

One more thing, I added a function <code>unicode_repr()</code> which is not implemented yet. Once we figure out what we're doing for suits, I will use that function to turn <code>(int, suit)</code> pairs into actual unicode card symbols.
